### PR TITLE
When checking if the piece is over, do not consider it over if there are no next_tracks if the piece is only 1 track long.

### DIFF
--- a/html/player/js/lib.js
+++ b/html/player/js/lib.js
@@ -411,7 +411,7 @@ cmas_playstate = function (state)
       }
     }
 
-    if (cmas_playbuffer.tracks[0] == state.track_window.current_track.id && state.track_window.next_tracks.length == 0) {
+    if (cmas_playbuffer.tracks[0] == state.track_window.current_track.id && (cmas_playbuffer.tracks.length != 1 && state.track_window.next_tracks.length == 0)) {
       console.log('Over, next');
       $("#globalslider-total").find('.bar').css('width', '0%');
       isover = true;


### PR DESCRIPTION
When in radio mode, if a chosen piece is 1 track long, it will load with no next_tracks. It will then immediately cause this if clause to trigger and a new piece chosen in radio mode, skipping over the single-track piece.

Fixes #29 