### PR TITLE
Explain browser support requires enabling DRM

### DIFF
--- a/html/player/index.html
+++ b/html/player/index.html
@@ -288,7 +288,7 @@
     </div>
     <div id="browsernotsupported" class="modal">
         <h2>Error</h2>
-        <p>Sorry. Due to Spotify limitations, this browser is not supported. Concertmaster works on Chrome and Firefox, desktop and Android versions.</p>
+        <p>Sorry. Due to Spotify's DRM restrictions, this browser is not supported. Concertmaster works on Chrome and Firefox, desktop and Android versions.</p>
         <p class="modaldetails">You can browse Concertmaster's catalogue, create playlists, favorite works, composers and recordings, but playback is disabled.</p>
         <a href="javascript:$('#browsernotsupported').closeModal()">Close</a>
     </div>


### PR DESCRIPTION
Browser: Firefox 111.0.1 (64-bit) macOS (with DRM plugin disabled)